### PR TITLE
Avoid infinite loop

### DIFF
--- a/variant_search/models/product.py
+++ b/variant_search/models/product.py
@@ -100,6 +100,7 @@ class ProductProductExt(models.Model):
 				search_domains = [('var_desc', operator, piece) for piece in pieces]
 			else:
 				search_domains = [('var_desc', operator, name)]
+			search_domains += args
 			_logger.debug('Qui domains=%s ', str(search_domains))
 			products = self.search(search_domains)
 			_logger.debug('Qui products=%s ', str(products))


### PR DESCRIPTION
I ended up with infinite loop coming from the "while" loop in product_template.py name_search function because it passes an additionnal domain [('product_tmpl_id', 'not in', templates.ids)] in the "args" that you are not forwarding to your name_search.
This fixes th issue.